### PR TITLE
Fix /api/set-port handler syntax

### DIFF
--- a/server.js
+++ b/server.js
@@ -592,17 +592,12 @@ app.post('/api/set-port', (req, res) => {
     connectedClients.clear();
     server = http.createServer(app);
     wss = new WebSocketServer({ server });
-server.close(() => {
-  wss.close();
-  connectedClients.clear();
-  server = http.createServer(app);
-  wss = new WebSocketServer({ server });
-  initWebSocketServer();
-  startServer(newPort).then(() => {
-    broadcast({ type: 'status', ...serverClockState });
-    res.json({ success: true });
+    initWebSocketServer();
+    startServer(newPort).then(() => {
+      broadcast({ type: 'status', ...serverClockState });
+      res.json({ success: true });
+    });
   });
-});
 
 });
 


### PR DESCRIPTION
## Summary
- clean up duplicated `server.close` blocks in `server.js`

## Testing
- `node -c server.js`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f5c94224483308327f9617d618919